### PR TITLE
fix: Wrong color display when uptime is 80 & 98

### DIFF
--- a/frontend/src/lib/components/datatables/xmr/UptimeCell.svelte
+++ b/frontend/src/lib/components/datatables/xmr/UptimeCell.svelte
@@ -2,9 +2,9 @@
 	export let uptime: number;
 </script>
 
-{#if uptime > 98}
+{#if uptime >= 98}
 	<span class="text-green-800 dark:text-green-500">{uptime}%</span>
-{:else if uptime < 98 && uptime > 80}
+{:else if uptime < 98 && uptime >= 80}
 	<span class="text-sky-800 dark:text-sky-500">{uptime}%</span>
 {:else if uptime < 80 && uptime > 75}
 	<span class="text-orange-800 dark:text-orange-300">{uptime}%</span>


### PR DESCRIPTION
The UI display red color if the uptime value is exactly 80 and 98 percent. Use `>=` fix this issue.