### PR TITLE
feat: Allow user to specify endpoint from CLI flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,18 +6,18 @@ LOG_LEVEL=INFO # can be DEBUG, INFO, WARN, ERROR
 # #############
 SERVER_ENDPOINT="http://127.0.0.1:18901"
 API_KEY=
-ACCEPT_TOR=true
+ACCEPT_TOR=false
 TOR_SOCKS="127.0.0.1:9050"
 
 # Server Config
 # #############
 
 # Fiber Config
-APP_PREFORK=true
+APP_PREFORK=false
 APP_HOST="127.0.0.1"
 APP_PORT=18090
-APP_PROXY_HEADER="X-Real-Ip" # CF-Connecting-IP
-APP_ALLOW_ORIGIN="http://localhost:5173,http://127.0.0.1:5173,https://ditatompel.com"
+APP_PROXY_HEADER="X-Real-Ip" # `CF-Connecting-IP` if using Cloudflare
+APP_ALLOW_ORIGIN="http://localhost:5173,http://127.0.0.1:5173,https://xmr.ditatompel.com"
 
 #DB settings:
 DB_HOST=127.0.0.1

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,7 @@
+linters-settings:
+  errcheck:
+    ignore: ""
+
 issues:
   exclude-rules:
     - path: frontend/embed.go

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -29,6 +29,8 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	Root.PersistentFlags().StringVarP(&configFile, "config-file", "c", "", "Default to .env")
 	Root.AddCommand(client.ProbeCmd)
+	client.ProbeCmd.Flags().StringP("endpoint", "e", "", "Server endpoint")
+	client.ProbeCmd.Flags().Bool("no-tor", false, "Only probe clearnet nodes")
 }
 
 func initConfig() {

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -19,9 +19,9 @@ type App struct {
 
 	// configuration for prober (client)
 	ServerEndpoint string
-	ApiKey         string
+	APIKey         string
 	AcceptTor      bool
-	TorSocks       string
+	TorSOCKS       string
 }
 
 var app = &App{}
@@ -54,7 +54,7 @@ func LoadApp() {
 
 	// prober configuration
 	app.ServerEndpoint = os.Getenv("SERVER_ENDPOINT")
-	app.ApiKey = os.Getenv("API_KEY")
+	app.APIKey = os.Getenv("API_KEY")
 	app.AcceptTor, _ = strconv.ParseBool(os.Getenv("ACCEPT_TOR"))
-	app.TorSocks = os.Getenv("TOR_SOCKS")
+	app.TorSOCKS = os.Getenv("TOR_SOCKS")
 }


### PR DESCRIPTION
User can specify custom server endpoint using  `--endpoint` flag from `probe` command.
`--no-tor` also added to `probe` CLI flags to force probing clearnet nodes only.

Another changes:
-  Lowercase & upperase initialism acronyms for `config.TorSocks` and `config.ApiKey` 3f5c0c9
-  Set default `ACCEPT_TOR` and `APP_PREFORK` config from `true` to `false`.  c0885f5
- Fix deprecated `linters.errcheck.ignore`. aa8ecc6