### PR TITLE
fix: Reject input hostname with protocol

### DIFF
--- a/internal/monero/monero.go
+++ b/internal/monero/monero.go
@@ -220,6 +220,10 @@ func (r *moneroRepo) Add(protocol string, hostname string, port uint) error {
 
 		ipAddr = hostIp.String()
 		ips = ip.SliceToString(hostIps)
+	} else {
+		if strings.HasPrefix(hostname, "http://") || strings.HasPrefix(hostname, "https://") {
+			return errors.New("Don't start hostname with http:// or https://, just put your hostname")
+		}
 	}
 
 	row, err := r.db.Query(`


### PR DESCRIPTION
This is quick fix.

Do not accept submitted tor address with protocol since it won't work.

The initial clearnet validation can be done with `net.LookupIP`, but for tor network can't be done with that method. For now, just inform to remove the http:// or https:// part to the submitter.