### PR TITLE
feat: Added tor hidden service via HTTP header

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The **clients** is used to fetch node information given by the server. First,
 it will ask the server which node to fetch. Then, it will fetch the information
 and report back to the server.
 
-The **server** serves an embedded Svelte static site for the Web UI. It also
-serves the `/api` endpoint that is used by the clients and the Web UI itself.
+The **server** serves the Web UI and the `/api` endpoint that is used by the
+clients.
 
 ## Requirements
 
@@ -121,7 +121,7 @@ Thank you!
 This project is licensed under [BSD-3-Clause](./LICENSE) license.
 
 [templ-repo]: https://github.com/a-h/templ "a-h/templ GitHub repository"
-[geoip-doc]: https://dev.maxmind.com/geoip/geoip2/geolite2/ "GeoIP documentation"
+[geoip-doc]: https://dev.maxmind.com/geoip/geolite2-free-geolocation-data/ "GeoLite2 Free documentation"
 [server-systemd-service]: ./deployment/init/xmr-nodes-server.service "systemd service example for server"
 [prober-systemd-service]: ./deployment/init/xmr-nodes-prober.service "systemd service example for prober"
 [prober-systemd-timer]: ./deployment/init/xmr-nodes-prober.timer "systemd timer example for prober"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ See the [Makefile](./Makefile).
 -   :white_check_mark: Use `a-h/templ` and `HTMX` instead of `Svelte`.
 -   Use Go standard `net/http` instead of `fiber`.
 -   :white_check_mark: Accept I2P nodes.
+-   :white_check_mark: Support Tor hidden service (beta, inform via HTTP header).
 
 ## Acknowledgement
 

--- a/deployment/nginx/vhost.conf
+++ b/deployment/nginx/vhost.conf
@@ -44,6 +44,9 @@ server {
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Download-Options noopen;
 
+    # Add your onion URL here if you support it
+    # add_header Onion-Location http://<YOUR-ONION-ADDRESS>.onion$request_uri;
+
     location = /robots.txt {
         log_not_found off;
         access_log    off;


### PR DESCRIPTION
The `Onion-Location` header was added to Nginx example configuration.

The address is `http://xmrlist2ug5ypisuhsvsi2req4bc3uiv3nc24yzibbaztslqprchvcad.onion`. (beta)