### PR TITLE
feat: "Filter by name or IP" input text is now searches for multiple IP address

### DIFF
--- a/internal/monero/monero.go
+++ b/internal/monero/monero.go
@@ -103,7 +103,7 @@ func (q *QueryNodes) toSQL() (args []interface{}, where string) {
 	wq := []string{}
 
 	if q.Host != "" {
-		wq = append(wq, "(hostname LIKE ? OR ip_addr LIKE ?)")
+		wq = append(wq, "(hostname LIKE ? OR ip_addresses LIKE ?)")
 		args = append(args, "%"+q.Host+"%", "%"+q.Host+"%")
 	}
 	if slices.Contains([]string{"mainnet", "stagenet", "testnet"}, q.Nettype) {

--- a/internal/monero/monero_test.go
+++ b/internal/monero/monero_test.go
@@ -87,7 +87,7 @@ func TestQueryNodes_toSQL(t *testing.T) {
 				CORS:       "",
 			},
 			wantArgs:    []interface{}{"%test%", "%test%"},
-			wantWhere:   "WHERE (hostname LIKE ? OR ip_addr LIKE ?)",
+			wantWhere:   "WHERE (hostname LIKE ? OR ip_addresses LIKE ?)",
 			wantSortBy:  "last_checked",
 			wantSortDir: "DESC",
 		},


### PR DESCRIPTION
`host` query string is now use `ip_addresses` column which mean it searches for multiple IP addresses instead of single IP.