### PR TITLE
Set spy_node, mrl and dns ban list default to N/A for newly added nodes

### DIFF
--- a/internal/monero/monero.go
+++ b/internal/monero/monero.go
@@ -360,8 +360,14 @@ func (r *moneroRepo) Add(submitterIP, salt, protocol, hostname string, port uint
 			last_checked,
 			last_check_status,
 			ip_addresses,
-			ipv6_only
+			ipv6_only,
+			is_spy_node,
+			mrl_ban_list_enabled,
+			dns_ban_list_enabled
 		) VALUES (
+			?,
+			?,
+			?,
 			?,
 			?,
 			?,
@@ -392,7 +398,10 @@ func (r *moneroRepo) Add(submitterIP, salt, protocol, hostname string, port uint
 		0,
 		string(statusDb),
 		ips,
-		ipv6_only)
+		ipv6_only,
+		2,
+		2,
+		2)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
You need to execute SQL query directly to the SQL server to update previous tor and i2p nodes record for this:

```sql
UPDATE tbl_node
SET
    `is_spy_node` = 2,
    `mrl_ban_list_enabled` = 2,
    `dns_ban_list_enabled` = 2
WHERE
    `is_tor` = 1 OR `is_i2p` = 1;
```